### PR TITLE
Bootstrap CI for 9.2.x

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -26,6 +26,14 @@ jobs:
           fetch-depth: 1
           path: prestashop
 
+      - name: Checkout PrestaShop repository (9.2.x)
+        uses: actions/checkout@v4
+        with:
+          repository: PrestaShop/PrestaShop
+          fetch-depth: 1
+          path: prestashop_92x
+          ref: 9.2.x
+
       - name: Checkout PrestaShop repository (9.1.x)
         uses: actions/checkout@v4
         with:

--- a/config.json
+++ b/config.json
@@ -9,6 +9,13 @@
     },
     {
       "repository": "PrestaShop/PrestaShop",
+      "path": "./prestashop_92x/",
+      "branch": "9.2.x",
+      "title": "9.2.x",
+      "type": "core"
+    },
+    {
+      "repository": "PrestaShop/PrestaShop",
       "path": "./prestashop_91x/",
       "branch": "9.1.x",
       "title": "9.1.x",


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | master
| Description?      | Add the new version branch `9.2.x` (opened for 9.2.0) to this repository's CI matrices / branch lists.
| Type?             | improvement
| Category?         | PM
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Review the diff: `9.2.x` is added wherever active version branches are enumerated.
| UI Tests          | N/A
| Fixed issue or discussion? | N/A
| Related PRs       | Companion PRs opened by the same "Version-branch bootstrap" run.
| Sponsor company   | N/A

> 🤖 Opened automatically by the **Version-branch bootstrap** workflow. Idempotent: re-running updates this PR; if it was closed, a new one is created.